### PR TITLE
docs: add Maven and PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We plan to expose much more of the _data_ via a companion website, such as numbe
 
 Merge Confidence badges for Pull Requests are available in beta on any supported Renovate platform today, including WhiteSource Remediate.
 
-Data is available for npm packages only for now, we plan to support other languages soon.
+Data is available for npm, Maven and PyPI packages only for now, we plan to support other languages soon.
 
 High-level information on planned enhancements is available in the [Merge Confidence Roadmap Project](https://github.com/whitesource/merge-confidence/projects/1) on GitHub.
 


### PR DESCRIPTION
I think https://github.com/whitesource/merge-confidence/commit/6e08d3eae22d281ff0478d4b36090b84cc6e90c0 and https://github.com/whitesource/merge-confidence/commit/b413c85d89814a119a872463594eaddf384ce38d added Maven and PyPi badges?

Maybe we should add them to the README?

---

EDIT:

Or are we waiting until issue #11 and #12 are done?